### PR TITLE
JBS-128: Increase threads-max and max pid value for ceph nodes

### DIFF
--- a/ceph/configure_ceph_nodes.yaml
+++ b/ceph/configure_ceph_nodes.yaml
@@ -49,3 +49,7 @@
    
     - name: Set up git
       shell: git config --global url."https://".insteadOf git://
+    - name: Increase threads-max limit
+      shell: sudo sysctl -w kernel.threads-max=4194303
+    - name: Increase allowed pid_max value
+      shell: sudo sysctl -w kernel.pid_max=4194303


### PR DESCRIPTION
With high number of pg's and osd's, we are running out
of threads, due to which osd's few wouldnt start.

Also, we might run out pids, so increased the same

Signed-off-by: shishir gowda <shishir.gowda@ril.com>